### PR TITLE
Hotfix/pg restore using wrong backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ docker-enter*
 log.txt
 *swp
 *-e
+base.log
+syslog.log
 push.log
 build.log
 postgres.log
@@ -25,3 +27,4 @@ stack*log
 buildtools.log
 jenkins.log
 buildtoolspush.log
+buildtools/pythonwheel/wheelhouse/*

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -65,7 +65,7 @@ if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
-  rm "${BACKUP_DIR}/*.download"
+  rm -f "${BACKUP_DIR}/*.download"
   sudo s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -64,6 +64,8 @@ LOCAL_BACKUP_FILE="${BACKUP_DIR}/${S3_BACKUP_FILE}.download"
 if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
+# A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
+  rm "${BACKUP_DIR}/*.download"
   sudo s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/fabfile.py
+++ b/db/postgres-restore/fabfile.py
@@ -28,22 +28,18 @@ def stop_host(instance_id):
 
 @task
 def install_postgres(private_ip,papertrail_address,vpc_cidr,database,s3_backup_bucket,s3_wale_bucket,pgversion):
-  run("cd ~/docker-stack && git pull origin hotfix/pgrestore-separation")
   run("~/docker-stack/db/postgres/new_postgres.sh %s %s %s %s %s %s %s" % (private_ip,papertrail_address,vpc_cidr,database,s3_backup_bucket,s3_wale_bucket,pgversion))
 
 @task
 def download_pgdump_backup(s3_bucket_host,db_name):
-  run("cd ~/docker-stack && git pull origin hotfix/pgrestore-separation")
   run("~/docker-stack/db/postgres-restore/download-pgdump-backup.sh %s %s" % (s3_bucket_host, db_name))
 
 @task
 def restore_pgdump_backup(db_name):
-  run("cd ~/docker-stack && git pull origin hotfix/pgrestore-separation")
   run("~/docker-stack/db/postgres-restore/restore-pgdump-backup.sh %s" % (db_name))
 
 @task
 def restore_pgdump_backup_schema_only(db_name):
-  run("cd ~/docker-stack && git pull origin hotfix/pgrestore-separation")
   run("~/docker-stack/db/postgres-restore/restore-pgdump-backup.sh --schema-only %s" % (db_name))
 
 #@task

--- a/db/postgres-restore/restore-pgdump-backup.sh
+++ b/db/postgres-restore/restore-pgdump-backup.sh
@@ -42,7 +42,7 @@ sudo supervisorctl restart postgres
 
 # if no backup file is provided, look for the most recent pgdump file in the backup dir
 if [[ -z "$LOCAL_BACKUP_FILE" ]]; then
-  LOCAL_BACKUP_FILE="$(find /media/data/postgres/backup -maxdepth 1 -iname "*.download"|tail -1)"
+  LOCAL_BACKUP_FILE="$(find /media/data/postgres/backup -maxdepth 1 -iname "*.download"| sort |tail -1)"
   if [[ -z "$LOCAL_BACKUP_FILE" ]]; then
     echo "No local backup found, exiting."
     exit 1


### PR DESCRIPTION
Fixes so that pg-restore actually loads the most recently downloaded backup.

Also include a fix to clean out local copies of old backups that have been downloaded, and no longer needed.