### PR TITLE
Change owner of download file for restore

### DIFF
--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -65,7 +65,7 @@ if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
-  sudo -u postgres rm -f "${BACKUP_DIR}/*.download"
+  sudo -u postgres rm "${BACKUP_DIR}/*.download"
   sudo -u postgres s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -65,7 +65,7 @@ if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
-  sudo -u postgres rm ${BACKUP_DIR}/*.download
+  sudo -u postgres rm -f ${BACKUP_DIR}/*.download
   sudo -u postgres s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -65,8 +65,7 @@ if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
-  #sudo -u postgres rm "${BACKUP_DIR}/*.download"
-  sudo rm "${BACKUP_DIR}/*.download"
+  sudo -u postgres rm ${BACKUP_DIR}/*.download
   sudo -u postgres s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -65,9 +65,8 @@ if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
-    HOST=`hostname`
-    echo  ${HOST}
-  sudo -u postgres rm "${BACKUP_DIR}/*.download"
+  #sudo -u postgres rm "${BACKUP_DIR}/*.download"
+  sudo rm "${BACKUP_DIR}/*.download"
   sudo -u postgres s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -65,8 +65,7 @@ if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
-  rm -f "${BACKUP_DIR}/*.download"
-  sudo s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
-  sudo chown postgres:postgres ${LOCAL_BACKUP_FILE}
+  sudo -u postgres rm -f "${BACKUP_DIR}/*.download"
+  sudo -u postgres s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -67,5 +67,6 @@ else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
   rm -f "${BACKUP_DIR}/*.download"
   sudo s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
+  sudo chown postgres:postgres ${LOCAL_BACKUP_FILE}
 fi
 export LOCAL_BACKUP_FILE

--- a/db/postgres-restore/download-pgdump-backup.sh
+++ b/db/postgres-restore/download-pgdump-backup.sh
@@ -65,6 +65,8 @@ if [[ -f "$LOCAL_BACKUP_FILE" ]] && ! [[ -z "$NO_OVERWRITE" ]]; then
   echo -e "\nFile $LOCAL_BACKUP_FILE already exists and -n option was given. Skipping."
 else
 # A little housecleaning- deleting any previous downloaded backups before gettign the new one. At some point this could be made optional (e.g. a -noclean option)
+    HOST=`hostname`
+    echo  ${HOST}
   sudo -u postgres rm "${BACKUP_DIR}/*.download"
   sudo -u postgres s3cmd --force get "s3://${S3_BUCKET}/${S3_YEAR}/${S3_MONTH}/${S3_BACKUP_FILE}" "$LOCAL_BACKUP_FILE"
 fi


### PR DESCRIPTION
Ran through several possible solutions of pulling down the file and changing the owner.  In the end, I went with doing a sudo -u postgres rather than doing a sudo to root.  This way the file is own by the same owner of the directory.
Also fixed the remove previous files as the quotes around the "${BACKUP_DIR}/*.download" should not have been around the whole thing.  With that, it was trying to find a file with the name *.download in the backup directory rather than using the * to glob the names.  