### PR TITLE
Corrections to fix-docker-deploy branch, when used directly in an instance

### DIFF
--- a/0099FF-stack/web/web.sh
+++ b/0099FF-stack/web/web.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-pushd /installs
+#pushd /installs
 sudo pip install -r requirements.txt
 
 #
@@ -10,6 +10,6 @@ sudo pip install -r requirements.txt
 #
 sudo pip install -r requirements2.txt
 
-popd
+#popd
 
 echo "Installed customer-specific web and worker portion"

--- a/db/postgres-standby/create-follower.sh
+++ b/db/postgres-standby/create-follower.sh
@@ -38,7 +38,7 @@ rm -f "$TMP_ETC_HOSTS"
 
 # skipped when using route53 for dns
 if [[ "$DNS_METHOD" = 'etchosts' ]]; then
-  etc_hosts_check "$PGMASTER_PRIVATEIP" pgsmaster-1
+  etc_hosts_check "$PGMASTER_PRIVATEIP" pgmaster-1
   etc_hosts_check "$PGFOLLOWER_PRIVATEIP" pgstandby-1
 fi
 

--- a/db/postgres-standby/create-follower.sh
+++ b/db/postgres-standby/create-follower.sh
@@ -2,6 +2,7 @@
 
 PGMASTER_PRIVATEIP=$1
 PGFOLLOWER_PRIVATEIP=$2
+DNS_METHOD=$3
 
 function etc_hosts_check
 {
@@ -35,8 +36,11 @@ cat "$TMP_ETC_HOSTS" | sudo tee /etc/hosts > /dev/null
 rm -f "$TMP_ETC_HOSTS"
 }
 
-#etc_hosts_check "$PGMASTER_PRIVATEIP" pgsmaster-1
-#etc_hosts_check "$PGFOLLOWER_PRIVATEIP" pgstandby-1
+# skipped when using route53 for dns
+if [[ "$DNS_METHOD" = 'etchosts' ]]; then
+  etc_hosts_check "$PGMASTER_PRIVATEIP" pgsmaster-1
+  etc_hosts_check "$PGFOLLOWER_PRIVATEIP" pgstandby-1
+fi
 
 ~/docker-stack/db/postgres-standby/init-standby.sh
 

--- a/db/postgres/config.sh
+++ b/db/postgres/config.sh
@@ -4,7 +4,6 @@ PGVERSION=$1
 DATABASE=$2
 VPC_CIDR=$3
 
-
 . ./postgresenv.sh $PGVERSION
 
 "${POSTGRESBINDIR}"/initdb -D "${POSTGRESDBDIR}" --locale=en_US.UTF-8

--- a/db/postgres/i-new_postgres.sh
+++ b/db/postgres/i-new_postgres.sh
@@ -35,6 +35,10 @@ sudo apt-fast -qq -y install python-dev python-pip
 cd ~/docker-stack/buildtools/utils || exit
 sudo ./install-supervisor.sh normal
 
+# create env variables so supervisor can start
+cd ~/utils || exit
+./environments/deployenv.sh linux common
+
 # enable logging
 cd ~/docker-stack/logging/ || exit
 ./i-enable-logging.sh "$PAPERTRAIL_ADDRESS"
@@ -43,10 +47,6 @@ cd ~/docker-stack/logging/ || exit
 cd ~/docker-stack/db/postgres/ || exit
 sudo sed -i '/\/dev\/xvdb[[:blank:]]\/mnt/d' /etc/fstab
 sudo ./mount.sh
-
-# create env variables so supervisor can start
-cd ~/utils || exit
-./environments/deployenv.sh linux common
 
 # install postgres and other tasks
 sudo ./postgres.sh "${PGVERSION}" "${DATABASE}" "${VPC_CIDR}"

--- a/db/postgres/i-new_postgres.sh
+++ b/db/postgres/i-new_postgres.sh
@@ -29,6 +29,9 @@ fi
 cd ~/docker-stack/buildtools/utils/ || exit
 sudo ./base-utils.sh
 
+cd ~/docker-stack/python/ || exit
+sudo ./python.sh
+
 cd ~/docker-stack/buildtools/utils || exit
 sudo ./install-supervisor.sh normal
 

--- a/db/postgres/i-new_postgres.sh
+++ b/db/postgres/i-new_postgres.sh
@@ -7,10 +7,22 @@ DATABASE=$4
 S3_BACKUP_BUCKET=$5
 S3_WALE_BUCKET=$6
 PGVERSION=$7
+DNS_METHOD=$8
 
-if [[ -z $PRIVATE_IP ]] || [[ -z $PAPERTRAIL_ADDRESS ]]; then
-  echo "usage: new_postgres.sh <private ip address> <papertrailurl:port>"
+if [[ -z "$PRIVATE_IP" ]] || [[ -z "$PAPERTRAIL_ADDRESS" ]] || [[ -z "$VPC_CIDR" ]] || [[ -z "$DATABASE" ]] || [[ -z "$S3_BACKUP_BUCKET" ]] || [[ -z "$S3_WALE_BUCKET" ]] || [[ -z "$PGVERSION" ]]; then
+  echo -e "usage: i-new_postgres.sh <private ip address> <papertrailurl:port> <vpc cidr> <database> <s3 backup bucket> <s3 wale bucket> <postgresql version> [<dns method>]\n"
+  echo -e "Examples:"
+  echo -e "Postgresql 9.4 using /etc/hosts for DNS:   ./i-new_postgres.sh 10.0.0.15 logs.papertrailapp.com:12345 10.0.0.0/16 test-postgres-backup-dev 9.4 etchosts"
+  echo -e "Postgresql 9.5 using Route53 for DNS:      ./i-new_postgres.sh 10.0.0.15 logs.papertrailapp.com:12345 10.0.0.0/16 test-postgres-backup-dev 9.5\n"
+  echo -e "Note: to use Route53 for DNS, you can omit the last argument.  To use the /etc/hosts file, add etchosts as the 8th and final argument."
   exit 1
+fi
+
+# if not using route53, add private IP to /etc/hosts
+if [[ "$DNS_METHOD" = 'etchosts' ]]; then
+  if ! (grep -q "^${PRIVATE_IP}\b.*\bpgmaster-1\b" /etc/hosts); then
+    echo "${PRIVATE_IP} pgmaster-1" | sudo tee -a /etc/hosts > /dev/null
+  fi
 fi
 
 # install standard packages/utilities
@@ -23,11 +35,6 @@ sudo ./install-supervisor.sh normal
 # enable logging
 cd ~/docker-stack/logging/ || exit
 ./i-enable-logging.sh "$PAPERTRAIL_ADDRESS"
-
-# add private IP to /etc/hosts
-#if ! (grep -q "^${PRIVATE_IP}\b.*\bpgmaster-1\b" /etc/hosts); then
-#  echo "${PRIVATE_IP} pgmaster-1" | sudo tee -a /etc/hosts > /dev/null
-#fi
 
 # mount volumes and remove instance attached store from /mnt
 cd ~/docker-stack/db/postgres/ || exit
@@ -53,12 +60,6 @@ if [[ ! -d /media/data/tmp ]]; then
 fi
 sudo chown ubuntu:ubuntu /media/data/tmp
 cd /media/data/tmp || exit
-
-# update postgresql.conf with pgtuned parameters
-#sudo apt-fast -y install pgtune
-#sudo pgtune -i /media/data/postgres/db/pgdata/postgresql.conf -o postgresql.conf.pgtune
-#sudo cp postgresql.conf.pgtune /media/data/postgres/db/pgdata/postgresql.conf
-#sudo supervisorctl restart postgres
 
 # enable ssl
 #sudo supervisorctl stop postgres

--- a/db/postgres/i-new_postgres.sh
+++ b/db/postgres/i-new_postgres.sh
@@ -39,6 +39,8 @@ sudo ./install-supervisor.sh normal
 cd ~/utils || exit
 ./environments/deployenv.sh linux common
 
+sudo /etc/init.d/supervisor start
+
 # enable logging
 cd ~/docker-stack/logging/ || exit
 ./i-enable-logging.sh "$PAPERTRAIL_ADDRESS"

--- a/db/postgres/i-new_postgres.sh
+++ b/db/postgres/i-new_postgres.sh
@@ -29,8 +29,8 @@ fi
 cd ~/docker-stack/buildtools/utils/ || exit
 sudo ./base-utils.sh
 
-cd ~/docker-stack/python/ || exit
-sudo ./python.sh
+# install python and pip directly rather than via python/python.sh
+sudo apt-fast -qq -y install python-dev python-pip
 
 cd ~/docker-stack/buildtools/utils || exit
 sudo ./install-supervisor.sh normal

--- a/db/postgres/i-new_postgres.sh
+++ b/db/postgres/i-new_postgres.sh
@@ -53,6 +53,9 @@ sudo ./mount.sh
 # install postgres and other tasks
 sudo ./postgres.sh "${PGVERSION}" "${DATABASE}" "${VPC_CIDR}"
 
+# restart supervisor to pick up new postgres files in conf.d
+sudo /etc/init.d/supervisor restart
+
 # get instance type to determine which base postgresql.conf to use
 INSTANCE_TYPE=$(curl http://169.254.169.254/latest/meta-data/instance-type)
 if [[ -f ~/docker-stack/db/postgres/conf/postgresql.conf.${INSTANCE_TYPE} ]]; then

--- a/db/postgres/i-new_postgres.sh
+++ b/db/postgres/i-new_postgres.sh
@@ -44,6 +44,10 @@ cd ~/docker-stack/db/postgres/ || exit
 sudo sed -i '/\/dev\/xvdb[[:blank:]]\/mnt/d' /etc/fstab
 sudo ./mount.sh
 
+# create env variables so supervisor can start
+cd ~/utils || exit
+./environments/deployenv.sh linux common
+
 # install postgres and other tasks
 sudo ./postgres.sh "${PGVERSION}" "${DATABASE}" "${VPC_CIDR}"
 

--- a/web/i-deploy_webandworker.sh
+++ b/web/i-deploy_webandworker.sh
@@ -44,16 +44,17 @@ sudo ./redis-client-install.sh
 cd ~/docker-stack/${STACK}-stack/web/ || exit
 sudo ./web.sh
 
-if [[ "$SUFFIX" = "worker" ]]; then
-  cd ~/docker-stack/${STACK}-stack/worker/ || exit
-  sudo ./worker.sh
-fi
+# guessing this was intended to eventually point to a file, but it doesn't currently exist.
+#if [[ "$SUFFIX" = "worker" ]]; then
+#  cd ~/docker-stack/${STACK}-stack/worker/ || exit
+#  sudo ./worker.sh
+#fi
 
 # Fix configuration files, using env vars distributed in the customer-specific (and private) utils.
 
 if [[ (-n "${ENV}") && (-e ~/utils/environments) ]]; then
   pushd ~/utils/
-  ./environments/deployenv.sh linux alol$ENV
+  ./environments/deployenv.sh linux $ENV
   popd
 fi
 


### PR DESCRIPTION
These changes were made to correct parts of the fix-docker-deploy branch
- which break when used directly in an instance
- add conditional support for either route53 or /etc/hosts for defining host addresses

This should have no impact on using docker stack within containers. 